### PR TITLE
Fix CUDA KV cache clear on non-host buffers

### DIFF
--- a/src/voxtral.cpp
+++ b/src/voxtral.cpp
@@ -1076,6 +1076,31 @@ static void clear_kv_cache(voxtral_context * ctx) {
     if (!ctx || !ctx->kv_self_k || !ctx->kv_self_v) {
         return;
     }
+    const bool k_host = ctx->kv_self_k->buffer != nullptr &&
+                        ggml_backend_buffer_is_host(ctx->kv_self_k->buffer);
+    const bool v_host = ctx->kv_self_v->buffer != nullptr &&
+                        ggml_backend_buffer_is_host(ctx->kv_self_v->buffer);
+
+    // On non-host buffers (CUDA/Vulkan/Metal), raw memset on ggml_get_data()
+    // may access device pointers and segfault. Clear through backend ops instead.
+    if (!k_host || !v_host) {
+        if (ctx->buf_persistent) {
+            ggml_backend_buffer_clear(ctx->buf_persistent, 0);
+        } else {
+            static thread_local std::vector<uint8_t> zeros(1 << 20, 0);
+
+            for (ggml_tensor * t : {ctx->kv_self_k, ctx->kv_self_v}) {
+                const size_t nbytes = ggml_nbytes(t);
+                for (size_t off = 0; off < nbytes; off += zeros.size()) {
+                    const size_t n = std::min(zeros.size(), nbytes - off);
+                    ggml_backend_tensor_set(t, zeros.data(), off, n);
+                }
+            }
+        }
+        ctx->kv_used = 0;
+        return;
+    }
+
     void * k_data = ggml_get_data(ctx->kv_self_k);
     void * v_data = ggml_get_data(ctx->kv_self_v);
     if (k_data) {
@@ -1091,6 +1116,15 @@ static void kv_cache_shift_left(voxtral_context * ctx, int32_t shift) {
     if (!ctx || shift <= 0 || !ctx->kv_self_k || !ctx->kv_self_v) {
         return;
     }
+    const bool k_host = ctx->kv_self_k->buffer != nullptr &&
+                        ggml_backend_buffer_is_host(ctx->kv_self_k->buffer);
+    const bool v_host = ctx->kv_self_v->buffer != nullptr &&
+                        ggml_backend_buffer_is_host(ctx->kv_self_v->buffer);
+    if (!k_host || !v_host) {
+        clear_kv_cache(ctx);
+        return;
+    }
+
     const int32_t window = VOXTRAL_DEC_WINDOW;
     if (shift >= window) {
         clear_kv_cache(ctx);


### PR DESCRIPTION
Note: This PR was assisted by AI but has been human-reviewed.

This fixes a CUDA crash when running with --gpu cuda.

The issue was caused by host-side memset/memmove on KV cache tensors (kv_self_k, kv_self_v) that can live in non-host backend buffers (CUDA/Vulkan/Metal). In that case, ggml_get_data() may not return host-safe memory, which can segfault.

# Crash path (reproducible on GTX 1080 Ti, sm_61):

- voxtral_transcribe_from_audio()
- clear_kv_cache()
- memset(ggml_get_data(kv_self_*), ...)

gdb points to:

- src/voxtral.cpp:1082 (clear_kv_cache)

# Fix

- In clear_kv_cache():
    - Detect whether KV tensors are host-backed via ggml_backend_buffer_is_host.
    - For non-host buffers, clear using backend-safe operations:
        - ggml_backend_buffer_clear(ctx->buf_persistent, 0) when available.
        - fallback to chunked ggml_backend_tensor_set(...) with zeroed data.
    - Keep direct memset only for host buffers.
- In kv_cache_shift_left():
    - Detect non-host KV buffers and avoid host memmove/memset.
    